### PR TITLE
Issue #6 feature(Database): Configure Liquibase for Order API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ server:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://localhost:8765/eureka
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/order_db

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,19 @@
+server:
+  port: 6061
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/order_db
+    username: postgres
+    password: 12345
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 spring:
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/db.changelog-master.xml
   profiles:
-    active: dev
+    active: test
   application:
     name: Order-Api

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,24 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="create_orders_tbl" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="orders"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/orders_v.0.0.0.sql"/>
+    </changeSet>
+
+    <changeSet id="create_order_items_tbl" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="order_items"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/order_items_v.0.0.1.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/order_items_v.0.0.1.sql
+++ b/src/main/resources/db/changelog/sql/order_items_v.0.0.1.sql
@@ -1,0 +1,8 @@
+CREATE TABLE order_items (
+    order_item_id BIGSERIAL PRIMARY KEY,
+    product_id BIGINT NOT NULL,
+    order_id BIGINT NOT NULL,
+    quantity INT NOT NULL CHECK (quantity > 0),
+    price NUMERIC(10,2) NOT NULL CHECK (price >= 0),
+    FOREIGN KEY (order_id) REFERENCES orders(order_id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/changelog/sql/orders_v.0.0.0.sql
+++ b/src/main/resources/db/changelog/sql/orders_v.0.0.0.sql
@@ -1,0 +1,6 @@
+CREATE TABLE orders (
+    order_id BIGSERIAL PRIMARY KEY,
+    order_amount NUMERIC(10,2) NOT NULL CHECK (order_amount >= 0),
+    coupon_code INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
Close #6 
This PR introduces Liquibase changesets to manage the database schema for the Order API Service. The changes include:

Create orders Table:

Added a changeset to create the orders table using the SQL file orders_v.0.0.0.sql.

Create order_items Table:

Added a changeset to create the order_items table using the SQL file order_items_v.0.0.1.sql.

This change introduces Liquibase for database schema management, enabling better tracking and versioning of database changes for the Order API Service.

