### PR TITLE
Close #31 Optimize ScheduledOutboxEventProcessor with JPQL Batch Update and Improved Reliability

### DIFF
--- a/src/main/java/com/fawry/order_api/application/usecase/OrderSagaUseCase.java
+++ b/src/main/java/com/fawry/order_api/application/usecase/OrderSagaUseCase.java
@@ -1,11 +1,9 @@
 package com.fawry.order_api.application.usecase;
 
 import com.fawry.kafka.events.OrderCancelNotificationEvent;
-import com.fawry.kafka.events.OrderCreatedEventDTO;
 import com.fawry.order_api.domain.model.Outbox;
 import com.fawry.order_api.domain.service.saga.OrderCompensationSagaService;
 import com.fawry.order_api.dto.dtos.DiscountDTO;
-import com.fawry.order_api.dto.dtos.OrderCreationResponse;
 import com.fawry.order_api.dto.enums.OrderSagaStatus;
 import com.fawry.order_api.exception.*;
 import com.fawry.order_api.infrastructure.messaging.producer.impl.OrderEventProducer;
@@ -56,7 +54,7 @@ public class OrderSagaUseCase implements OrderCreationSagaService, OrderCancella
     @Override
     @Async("orderTaskExecutor")
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void createOrderSaga(OrderRequest request) {
+    public CompletableFuture<Void> createOrderSaga(OrderRequest request) {
         Long userId = orderUserAuth.parseUserId();
         Order order = createAndSaveOrder(request, userId);
 
@@ -71,6 +69,8 @@ public class OrderSagaUseCase implements OrderCreationSagaService, OrderCancella
         }
 
         saveOrderEventToDatabase(request, order, OrderSagaStatus.CREATED, getCustomerEmail());
+        return CompletableFuture.completedFuture(null);
+
     }
 
     private Order createAndSaveOrder(OrderRequest request, Long userId) {

--- a/src/main/java/com/fawry/order_api/domain/model/Outbox.java
+++ b/src/main/java/com/fawry/order_api/domain/model/Outbox.java
@@ -4,10 +4,7 @@ import com.fawry.order_api.dto.enums.OrderSagaStatus;
 import com.fawry.order_api.dto.enums.SagaEventType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.math.BigDecimal;
@@ -17,6 +14,7 @@ import java.time.Instant;
 @NoArgsConstructor
 @Setter
 @Getter
+@ToString
 @Entity
 @Table(name = "outbox")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/fawry/order_api/domain/service/saga/OrderCreationSagaService.java
+++ b/src/main/java/com/fawry/order_api/domain/service/saga/OrderCreationSagaService.java
@@ -1,8 +1,9 @@
 package com.fawry.order_api.domain.service.saga;
 
 import com.fawry.order_api.dto.dtos.OrderRequest;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public interface OrderCreationSagaService {
-    void createOrderSaga(OrderRequest request) throws ExecutionException, InterruptedException;
+    CompletableFuture<Void> createOrderSaga(OrderRequest request) throws ExecutionException, InterruptedException;
 }

--- a/src/main/java/com/fawry/order_api/infrastructure/messaging/producer/impl/OrderCreatedPublisherImpl.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/messaging/producer/impl/OrderCreatedPublisherImpl.java
@@ -1,6 +1,7 @@
 package com.fawry.order_api.infrastructure.messaging.producer.impl;
 
 import com.fawry.kafka.events.OrderCreatedEventDTO;
+import com.fawry.order_api.exception.OrderProcessingException;
 import com.fawry.order_api.infrastructure.messaging.producer.OrderCreatedEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -29,13 +30,13 @@ public class OrderCreatedPublisherImpl implements OrderCreatedEventPublisher {
 
     @Override
     public void publishOrderCreatedEvent(OrderCreatedEventDTO createdEvent, int orderHash) {
-        Message<OrderCreatedEventDTO> message =
-                MessageBuilder
-                        .withPayload(createdEvent)
-                        .setHeader(TOPIC, TOPIC_NAME)
-                        .setHeader(PARTITION, 0)
-                        .build();
-        kafkaTemplate.send(message);
+            Message<OrderCreatedEventDTO> message =
+                    MessageBuilder
+                            .withPayload(createdEvent)
+                            .setHeader(TOPIC, TOPIC_NAME)
+                            .setHeader(PARTITION, 0)
+                            .build();
+            kafkaTemplate.send(message);
     }
 
 }

--- a/src/main/java/com/fawry/order_api/infrastructure/messaging/producer/impl/OrderEventProducer.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/messaging/producer/impl/OrderEventProducer.java
@@ -6,8 +6,9 @@ import com.fawry.order_api.infrastructure.messaging.producer.OrderCancelEventPub
 import com.fawry.order_api.infrastructure.messaging.producer.OrderCreatedEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.apache.kafka.common.KafkaException;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
@@ -20,12 +21,23 @@ public class OrderEventProducer <T>{
     private final OrderCreatedEventPublisher orderCreatedPublisher;
     private final OrderCancelEventPublisher orderCancellationPublisher;
 
-    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000, random = true))
+   @Retryable(
+           maxAttempts = 3,
+           backoff = @Backoff(delay = 1000),
+           retryFor = KafkaException.class,
+           exceptionExpression = "!(#exception instanceof OrderNotFoundException)"
+   )
     public void processEventProducer(T event, int orderHash) {
         if (event instanceof OrderCreatedEventDTO) {
             orderCreatedPublisher.publishOrderCreatedEvent((OrderCreatedEventDTO) event, orderHash);
         }else if (event instanceof OrderCancelNotificationEvent) {
             orderCancellationPublisher.publishOrderCanceledEvent((OrderCancelNotificationEvent) event, orderHash);
         }
+    }
+
+    @Recover
+    public void recover(KafkaException e, T event, int orderHash) {
+       log.error("Failed to publish event after 3 retries: {}. Event: {}", e.getMessage(), event);
+       throw new RuntimeException("Failed to publish event to kafka after retries");
     }
 }

--- a/src/main/java/com/fawry/order_api/infrastructure/outbox/ScheduledOutboxEventProcessor.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/outbox/ScheduledOutboxEventProcessor.java
@@ -15,7 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
-
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,7 +36,6 @@ class ScheduledOutboxEventProcessor implements OutboxService {
         while (isFailedProcessing) {
             isFailedProcessing = Boolean.TRUE.equals(transactionTemplate.execute(this::doInTransaction));
         }
-
     }
 
     private Boolean doInTransaction(TransactionStatus status) {
@@ -44,21 +43,27 @@ class ScheduledOutboxEventProcessor implements OutboxService {
                 .orElse(Collections.emptyList());
 
         if (!outboxes.isEmpty()) {
+            List<Long> successfulOutboxIds = new ArrayList<>();
             for (Outbox outbox : outboxes) {
                 Order order = orderRepository.findWithOrderItemsById(outbox.getOrderId())
                         .orElseThrow(() -> new OrderNotFoundException(outbox.getOrderId()));
                 sendEventToKafka(outbox, order);
-                outbox.setProcessed(Boolean.TRUE);
-                outboxRepository.save(outbox);
+                successfulOutboxIds.add(outbox.getId());
             }
+            outboxRepository.updateProcessedByIds(Boolean.TRUE, successfulOutboxIds);
             return true;
         }
         return false;
     }
 
     private void sendEventToKafka(Outbox outbox, Order order) {
-        OrderCreatedEventDTO orderCreatedEventDTO = outboxMapper.mapToOrderCreatedEventDTO(outbox, order);
-        log.info("Processing to poll OutboxEvent from database to kafka: {}", orderCreatedEventDTO);
-        producer.processEventProducer(orderCreatedEventDTO, order.hashCode());
+        try {
+            OrderCreatedEventDTO orderCreatedEventDTO = outboxMapper.mapToOrderCreatedEventDTO(outbox, order);
+            log.info("Processing to poll OutboxEvent from database to kafka: {}", orderCreatedEventDTO);
+            producer.processEventProducer(orderCreatedEventDTO, order.hashCode());
+        }catch (Exception e) {
+            throw e;
+        }
+
     }
 }

--- a/src/main/java/com/fawry/order_api/infrastructure/repository/OutboxRepository.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/repository/OutboxRepository.java
@@ -2,11 +2,21 @@ package com.fawry.order_api.infrastructure.repository;
 
 import com.fawry.order_api.domain.model.Outbox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface OutboxRepository extends JpaRepository<Outbox, Long> {
-    Optional<List<Outbox>> findTop100ByProcessed(Boolean processed);
+
+    Optional<List<Outbox>> findTop10ByProcessed(Boolean processed);
+
+    @Modifying
+    @Query("""
+            UPDATE Outbox o SET o.processed = :outboxProcessing WHERE o.id IN :ids
+            """)
+    void updateProcessedByIds(@Param("outboxProcessing") Boolean processed, @Param("ids") List<Long> outboxIds);
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,6 +13,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+      order_inserts: true
+      order_updates: true
+      jdbc:
+        batch_size: 50
+        batch_versioned_data: true
     show-sql: true
     properties:
       hibernate:
@@ -38,6 +43,8 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
+        properties:
+          metadata.fetch.timeout.ms: 1000
         spring.json.add.type.headers: true
         spring.json.type.mapping: orderCreatedEventDTO:com.fawry.kafka.events.OrderCreatedEventDTO, orderCancelNotificationEvent:com.fawry.kafka.events.OrderCancelNotificationEvent
   redis:


### PR DESCRIPTION
Close #31 
This PR optimizes the ScheduledOutboxEventProcessor to improve performance and reliability as outlined in the related issue. The main changes include replacing save with a JPQL batch update query, adding better error handling to ensure only successfully published events are marked as processed.

Changes:
Batch Update with JPQL Query:
Replaced outboxRepository.saveAll with updateProcessedByIds to update the processed field in a single query (UPDATE Outbox o SET o.processed = :outboxProcessing WHERE o.id IN :ids).
Reduced database load from 10 queries to 1 per transaction.
Improved Error Handling:
Added successfulOutboxIds to collect IDs of Outbox entities that are successfully published to Kafka.
Only events that are successfully published are marked as processed = true.