### PR TITLE
Close #33 Optimize Outbox Query with Composite Index and FIFO Ordering

### DIFF
--- a/src/main/java/com/fawry/order_api/domain/model/Outbox.java
+++ b/src/main/java/com/fawry/order_api/domain/model/Outbox.java
@@ -72,7 +72,7 @@ public class Outbox {
     @NotNull
     @Column(name = "created_at", nullable = false)
     @CreatedDate
-    private Instant orderDate;
+    private Instant createdAt;
 
     @NotNull
     @Column(name = "processed", nullable = false)

--- a/src/main/java/com/fawry/order_api/infrastructure/outbox/ScheduledOutboxEventProcessor.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/outbox/ScheduledOutboxEventProcessor.java
@@ -39,7 +39,7 @@ class ScheduledOutboxEventProcessor implements OutboxService {
     }
 
     private Boolean doInTransaction(TransactionStatus status) {
-        List<Outbox> outboxes = outboxRepository.findTop10ByProcessed(Boolean.FALSE)
+        List<Outbox> outboxes = outboxRepository.findTop10ByProcessedOrderByCreatedAt(Boolean.FALSE)
                 .orElse(Collections.emptyList());
 
         if (!outboxes.isEmpty()) {
@@ -64,6 +64,5 @@ class ScheduledOutboxEventProcessor implements OutboxService {
         }catch (Exception e) {
             throw e;
         }
-
     }
 }

--- a/src/main/java/com/fawry/order_api/infrastructure/repository/OutboxRepository.java
+++ b/src/main/java/com/fawry/order_api/infrastructure/repository/OutboxRepository.java
@@ -12,11 +12,14 @@ import java.util.Optional;
 @Repository
 public interface OutboxRepository extends JpaRepository<Outbox, Long> {
 
-    Optional<List<Outbox>> findTop10ByProcessed(Boolean processed);
+
+    Optional<List<Outbox>> findTop10ByProcessedOrderByCreatedAt(Boolean processed);
 
     @Modifying
     @Query("""
-            UPDATE Outbox o SET o.processed = :outboxProcessing WHERE o.id IN :ids
+            UPDATE Outbox o
+            SET o.processed = :outboxProcessing
+            WHERE o.id IN :ids
             """)
     void updateProcessedByIds(@Param("outboxProcessing") Boolean processed, @Param("ids") List<Long> outboxIds);
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -34,4 +34,23 @@
         </preConditions>
         <sqlFile path="db/changelog/sql/outbox_table_v.1.1.2.sql"/>
     </changeSet>
+
+    <changeSet id="create_idx_outbox_processed" author="muhammad hussein" context="development">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_outbox_processed"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/idx_outbox_processed_v.1.2.2.sql"/>
+    </changeSet>
+
+    <changeSet id="create_idx_outbox_processed_created_at" author="muhammad hussein" context="development,staging,production">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_outbox_processed_created_at"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/idx_outbox_processed_created_at_v.2.2.2.sql"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/idx_outbox_processed_created_at_v.2.2.2.sql
+++ b/src/main/resources/db/changelog/sql/idx_outbox_processed_created_at_v.2.2.2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_outbox_processed_created_at ON outbox (processed, created_at);

--- a/src/main/resources/db/changelog/sql/idx_outbox_processed_v.1.2.2.sql
+++ b/src/main/resources/db/changelog/sql/idx_outbox_processed_v.1.2.2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_outbox_processed ON outbox (processed);


### PR DESCRIPTION
Close #33 
This PR optimizes the ScheduledOutboxEventProcessor by ensuring Outbox events are processed in FIFO order (ordered by createdAt ascending) and improving query performance with a composite index. The findTop10ByProcessed method is replaced with findTop10ByProcessedOrderByCreatedAt to fetch events in FIFO order. A composite index idx_outbox_processed_created_at is added on outbox (processed, created_at) to optimize the query. Liquibase ChangeSets are included to apply the idx_outbox_processed index in development and the idx_outbox_processed_created_at index in development, staging, and production environments.

Changes:
FIFO Ordering:
Replaced findTop10ByProcessed with findTop10ByProcessedOrderByCreatedAt in OutboxRepository to fetch unprocessed Outbox events ordered by createdAt in ascending order.
Updated doInTransaction in ScheduledOutboxEventProcessor to use the new method for FIFO processing.
Composite Index:
Added composite index idx_outbox_processed_created_at on outbox (processed, created_at) to improve query performance.
SQL: CREATE INDEX idx_outbox_processed_created_at ON outbox (processed, created_at);
Liquibase ChangeSets:
Added ChangeSet create_idx_outbox_processed to apply the idx_outbox_processed index in the development environment.
Added ChangeSet create_idx_outbox_processed_created_at to apply the idx_outbox_processed_created_at index in development, staging, and production environments.

How to Test:
1. Setup:
  Start the application with Postgres and Kafka running locally (or use Docker: docker-compose up if available).
  Ensure the outbox table exists with the necessary columns (processed, created_at).
  Insert test Outbox events with different createdAt values:
  `INSERT INTO outbox (outbox_id, order_id, event_type, payload, created_at, processed)
  VALUES (1, 1, 'OrderCreatedEvent', '{"orderId": 1}', '2025-04-07 10:00:00', false),
         (2, 2, 'OrderCreatedEvent', '{"orderId": 2}', '2025-04-07 10:01:00', false),
         (3, 3, 'OrderCreatedEvent', '{"orderId": 3}', '2025-04-07 10:02:00', false);`
2. Run the following query and use EXPLAIN to verify that the index is used:
  sql
  `EXPLAIN SELECT * FROM outbox WHERE processed = false ORDER BY created_at LIMIT 10;`

3. Test FIFO Processing:
  Start the application and wait 5 seconds (based on the scheduled delay).
  Verify that the ScheduledOutboxEventProcessor processes the events in FIFO order (oldest first):
  Event with outbox_id = 1 (created at 10:00:00) should be processed first.
  Event with outbox_id = 2 (created at 10:01:00) should be processed second.
  Event with outbox_id = 3 (created at 10:02:00) should be processed third.
  Check the outbox table: SELECT * FROM outbox WHERE outbox_id IN (1, 2, 3); should show processed = true for all events.